### PR TITLE
Fix multiBandDriver.py instruction.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -261,7 +261,7 @@ There is no need to run these tasks independently; the `multiBandDriver.py` scri
 
   multiBandDriver.py DATA --rerun example2:example3 \
     --id tract=0 patch=1,1 filter=HSC-R^HSC-I \
-    --cores=2 -C no-bright-object-mask.py
+    --cores=2
 
 We've run only the middle patch here.  Because there's so little data here, the outer patches have a lot of area with no valid pixels, and coadd processing will fail if there is too much missing area (unless you set some other configuration options we won't go into here).  You'll also see a lot of warnings about failed measurements even on the middle patch for the same reason.  Because we're only running one patch, we're also only using two cores, as that's the most the script will be able to make use of (because there are two filters).
 


### PR DESCRIPTION
Removed extraneous "-C no-bright-object-mask.py" keyword argument
from multiBandDriver.py instruction, which was referring to a file that
no longer exists.
