### PR TITLE
DM-12531: Update to reflect new behavior after RFCs 407 and 409.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -361,20 +361,24 @@ Frequently Encountered Problems
 Configuration and Software Version Changes
 ------------------------------------------
 
-The first time a commmand-line task is run in a chain of data repositories, the versions of all of the software it uses and the full configuration tree are saved to the output repositories.  The next time that task is run, the versions and configuration are compared against the saved versions, and the task will fail if they're not the same.  This is usually desirable in production environments, where it's important that all data units be processed the same way.  It would be desirable to make the comparison only happen within one rerun, not a full rerun chain -- but this is not yet implemented.
+The first time a commmand-line task is run in an output data repositoriy, the versions of all of the software it uses and the full configuration tree are saved.
+The next time that task is run (with the same output repository), the versions and configuration are compared against the saved versions, and the task will fail if they're not the same.
+This is usually desirable; we don't want the data products in a single repository to be produced in an inconsistent way.
 
-In testing work, this behavior is frequently inconvenient, and the pipeline provides options to override it: ``--clobber-config`` and ``--clobber-versions`` will simply overwite the existing configuration and version information (respectively), and ``--no-versions`` will prevent version information from being written or tested entirely.
+Sometimes in testing work, we want to just reuse a single output repository for lots of throwaway processing runs that aren't expected to be consistent.
+When that's the case, you can override this behavior: ``--clobber-config`` and ``--clobber-versions`` will simply overwite the existing configuration and version information (respectively), and ``--no-versions`` will prevent version information from being written or tested entirely.
 
-These tests can also be dangrous in parallel execution, as they can be subject to race conditions (because one process can be testing for the existing of the file while another is writing it).  The built-in parallelization provided by the various :py:class:`lsst.ctrl.pool.BatchParallelTask` options and ``-j`` are safe in this respect; these do the writing and comparisons in a single process before starting the parallel processing.  External wrappers that run the same task in multiple processes may not be safe, especially if the ``--clobber-*`` operations are being used; the default behavior is protected from race conditions by using a locking approach based on operations that are atomic on most filesystems, but the ``--clobber-*`` options are not.
+These tests can also be dangerous in parallel execution, as they can be subject to race conditions (because one process can be testing for the existing of the file while another is writing it).  The built-in parallelization provided by the various :py:class:`lsst.ctrl.pool.BatchParallelTask` options and ``-j`` are safe in this respect; these do the writing and comparisons in a single process before starting the parallel processing.  External wrappers that run the same task in multiple processes may not be safe, especially if the ``--clobber-*`` operations are being used; the default behavior is protected from race conditions by using a locking approach based on operations that are atomic on most filesystems, but the ``--clobber-*`` options are not.
 
 .. _clobbering-and-skiping:
 
 Clobbering and Skipping Outputs
 -------------------------------
 
-Some command-line tasks (especially the ``*Driver.py`` tasks) test whether a data product exists in the current rerun chain, and skip any processing that would be replace it.  This is exactly the behavior desired when a large job dies unexpected and you want to resume it.  But it can be very confusing when you actually want to re-do the processing (especially the fact that processing is skipped if the output data product appears anywhere in the rerun *chain*, not just the last rerun in the chain -- this is another behavior we plan to change in the future).
-
-Tasks with this behavior have configuration parameters to disable it, usually with names with words like "overwrite", "clobber", or "skip".  Because these are configuration parameters (not normal command-line options), changing them and then restarting processing in the same rerun will trigger an error of the type described in the :ref:`previous section <configuration-and-software-version-changes>`.
+The ``multibandDriver.py`` and ``coaddDriver.py`` scripts can test whether a data product exists in the output repository, and skip any processing that would replace it.
+This is exactly the behavior desired when a large job dies unexpectedly and you want to resume it, but it can be very confusing when you actually want to re-do the processing, so it's not enabled by default.
+To turn it on, pass ``--reuse-outputs-from all`` on the command line.
+You can also pass the name of a subtask (e.g. ``mergeCoaddDetections`` for ``multibandDriver.py``) instead of ``all`` to allow skipping that step *and* any previous steps.
 
 
 References


### PR DESCRIPTION
This update actually captures changes introduced in DM-12450 as well as those introduced in DM-12531, but I figured splitting up the documentation update across those tickets wasn't worth the overhead.